### PR TITLE
feat: 實作動態 FalkorDB 主機檢測機制

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,11 @@ OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 # OPENROUTER_API_KEY=or-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # === Database Configuration ===
-FALKORDB_HOST=falkordb
+# FALKORDB_HOST 將透過動態檢測自動設定：
+# - Docker 容器內 → falkordb
+# - 本機環境 → localhost
+# 如需強制指定，可以取消以下註釋：
+# FALKORDB_HOST=localhost
 FALKORDB_PORT=6379
 FALKORDB_DATABASE=mnemosyne
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - "50051:50051"  # gRPC port
     env_file: .env
     environment:
-      - FALKORDB_HOST=falkordb
+      - RUNNING_IN_DOCKER=1
       - FALKORDB_PORT=6379
       - FALKORDB_DATABASE=mnemosyne
       - LOG_LEVEL=INFO

--- a/src/mnemosyne/core/config.py
+++ b/src/mnemosyne/core/config.py
@@ -16,12 +16,45 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from ..interfaces.graph_store import ConnectionConfig
 
 
+def _get_default_falkordb_host() -> str:
+    """
+    動態解析 FalkorDB 主機地址的 default_factory
+
+    邏輯：
+    - 在 Docker 容器內 → 使用 'falkordb' (容器名稱)
+    - 在本機環境 → 使用 'localhost' (port forwarding)
+    """
+    # 方法1：檢查環境變數
+    if os.getenv("RUNNING_IN_DOCKER") == "1":
+        print("[INFO] FalkorDB host: falkordb (detected via RUNNING_IN_DOCKER env var)")
+        return "falkordb"
+
+    # 方法2：檢查 /.dockerenv 文件（Docker 容器內會有此文件）
+    if Path("/.dockerenv").exists():
+        print("[INFO] FalkorDB host: falkordb (detected via /.dockerenv file)")
+        return "falkordb"
+
+    # 方法3：檢查 /proc/1/cgroup 內容（更可靠的檢測方式）
+    try:
+        with open("/proc/1/cgroup", "r") as f:
+            content = f.read()
+            if "docker" in content or "containerd" in content:
+                print("[INFO] FalkorDB host: falkordb (detected via /proc/1/cgroup)")
+                return "falkordb"
+    except (FileNotFoundError, PermissionError):
+        pass
+
+    # 本機環境預設使用 localhost
+    print("[INFO] FalkorDB host: localhost (local environment default)")
+    return "localhost"
+
+
 class DatabaseSettings(BaseSettings):
     """資料庫配置"""
 
     model_config = SettingsConfigDict(env_prefix="FALKORDB_", case_sensitive=False)
 
-    host: str = Field(default="localhost")
+    host: str = Field(default_factory=_get_default_falkordb_host)
     port: int = Field(default=6379)
     database: str = Field(default="mnemosyne")
     username: Optional[str] = Field(default=None)


### PR DESCRIPTION
## 📋 概要

實作動態 FalkorDB 主機檢測機制，解決 `make doctor` 在本機環境執行時的連接問題。

## 🔧 主要變更

### 核心功能
- ✅ 新增 `_get_default_falkordb_host()` 函數，支援動態主機檢測
- ✅ 實作多重檢測機制：
  - 環境變數 `RUNNING_IN_DOCKER=1`
  - 檢查 `/.dockerenv` 文件
  - 檢查 `/proc/1/cgroup` 內容

### 配置優化
- ✅ 更新 `.env.example`：移除硬編碼的 `FALKORDB_HOST` 設定
- ✅ 更新 `docker-compose.yml`：使用 `RUNNING_IN_DOCKER=1` 環境變數
- ✅ 確保容器內外環境自動適配

## ✅ 運行邏輯

| 環境 | 主機地址 | 檢測方式 |
|------|----------|----------|
| **Docker 容器內** | `falkordb` | 自動檢測容器環境 |
| **本機環境** | `localhost` | 預設本機環境 |

## 🎯 解決問題

- ❌ **修復前**: `make doctor` 在本機執行時出現 `getaddrinfo ENOTFOUND falkordb` 錯誤
- ✅ **修復後**: 自動適配執行環境，無需手動配置

## 📊 測試結果

### 本機環境
```bash
$ make doctor
[INFO] FalkorDB host: localhost (local environment default)
✅ 資料庫連接正常
   - 主機: localhost
   - 端口: 6379
```

### Docker 環境
```bash
$ docker exec mnemosyne-api python -m mnemosyne.cli.main doctor
[INFO] FalkorDB host: falkordb (detected via RUNNING_IN_DOCKER env var)
✅ 資料庫連接正常
   - 主機: falkordb
   - 端口: 6379
```

## 📚 技術細節

- 使用 Pydantic Settings 的 `default_factory` 機制
- 多層級檢測確保環境識別準確性
- 診斷輸出清楚顯示主機解析來源

🤖 Generated with [Claude Code](https://claude.ai/code)